### PR TITLE
refactor: move top level functions as method on an API struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ import (
 )
 
 func main() {
-    i, err := depsdev.GetInfo("npm", "defangjs")
+    client:= depsdev.NewAPI()
+    i, err := client.GetInfo("npm", "defangjs")
     if err != nil {
      fmt.Println(err)
     }

--- a/cmd/advisory.go
+++ b/cmd/advisory.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/edoardottt/depsdev/pkg/depsdev"
 	"github.com/edoardottt/depsdev/pkg/input"
 	"github.com/edoardottt/depsdev/pkg/output"
 	"github.com/spf13/cobra"
@@ -37,7 +36,7 @@ var advisoryCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		a, err := depsdev.GetAdvisory(args[0])
+		a, err := api.GetAdvisory(args[0])
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/edoardottt/depsdev/pkg/depsdev"
 	"github.com/edoardottt/depsdev/pkg/input"
 	"github.com/edoardottt/depsdev/pkg/output"
 	"github.com/spf13/cobra"
@@ -40,7 +39,7 @@ var depsCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		d, err := depsdev.GetDependencies(args[0], args[1], args[2])
+		d, err := api.GetDependencies(args[0], args[1], args[2])
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/edoardottt/depsdev/pkg/depsdev"
 	"github.com/edoardottt/depsdev/pkg/input"
 	"github.com/edoardottt/depsdev/pkg/output"
 	"github.com/spf13/cobra"
@@ -40,7 +39,7 @@ var graphCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		d, err := depsdev.GetDependencies(args[0], args[1], args[2])
+		d, err := api.GetDependencies(args[0], args[1], args[2])
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/edoardottt/depsdev/pkg/depsdev"
 	"github.com/edoardottt/depsdev/pkg/input"
 	"github.com/edoardottt/depsdev/pkg/output"
 	"github.com/spf13/cobra"
@@ -45,7 +44,7 @@ including its licenses and any security advisories known to affect it.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) > 2 {
-			v, err := depsdev.GetVersion(args[0], args[1], args[2])
+			v, err := api.GetVersion(args[0], args[1], args[2])
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -57,7 +56,7 @@ including its licenses and any security advisories known to affect it.`,
 
 			fmt.Println(vJSON)
 		} else {
-			p, err := depsdev.GetInfo(args[0], args[1])
+			p, err := api.GetInfo(args[0], args[1])
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/edoardottt/depsdev/pkg/depsdev"
 	"github.com/edoardottt/depsdev/pkg/input"
 	"github.com/edoardottt/depsdev/pkg/output"
 	"github.com/spf13/cobra"
@@ -37,7 +36,7 @@ var projectCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		p, err := depsdev.GetProject(args[0])
+		p, err := api.GetProject(args[0])
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/edoardottt/depsdev/pkg/depsdev"
 	"github.com/edoardottt/depsdev/pkg/input"
 	"github.com/edoardottt/depsdev/pkg/output"
 	"github.com/spf13/cobra"
@@ -40,7 +39,7 @@ and any given artifact may appear in many package versions.`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		p, err := depsdev.GetQuery(args[0])
+		p, err := api.GetQuery(args[0])
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,15 +17,21 @@ package cmd
 import (
 	"os"
 
+	"github.com/edoardottt/depsdev/pkg/depsdev"
 	"github.com/edoardottt/depsdev/pkg/output"
 	"github.com/spf13/cobra"
 )
+
+var api *depsdev.API
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "depsdev",
 	Short: output.ShortDescription,
 	Long:  output.Banner,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		api = depsdev.NewAPI()
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/pkg/depsdev/api.go
+++ b/pkg/depsdev/api.go
@@ -31,24 +31,9 @@ func NewAPI() *API {
 	}
 }
 
+// GetInfo returns information about a package for a specific package manager.
 func (a *API) GetInfo(packageManager, packageName string) (Package, error) {
 	return getPackage(a.client, packageManager, packageName)
-}
-
-func (a *API) GetVersion(packageManager, packageName, version string) (Version, error) {
-	return getVersion(a.client, packageManager, packageName, version)
-}
-
-// GetInfo returns information about a package for a specific package manager.
-func GetInfo(packageManager, packageName string) (Package, error) {
-	c := client.New(BasePath)
-
-	p, err := getPackage(c, packageManager, packageName)
-	if err != nil {
-		return Package{}, err
-	}
-
-	return p, nil
 }
 
 // getPackage returns a Package object.
@@ -65,15 +50,8 @@ func getPackage(c *client.Client, packageManager, packageName string) (Package, 
 
 // GetVersion returns information about a specific version of a package
 // for a specific package manager.
-func GetVersion(packageManager, packageName, version string) (Version, error) {
-	c := client.New(BasePath)
-
-	v, err := getVersion(c, packageManager, packageName, version)
-	if err != nil {
-		return Version{}, err
-	}
-
-	return v, nil
+func (a *API) GetVersion(packageManager, packageName, version string) (Version, error) {
+	return getVersion(a.client, packageManager, packageName, version)
 }
 
 // getVersion returns a Version object.
@@ -90,15 +68,8 @@ func getVersion(c *client.Client, packageManager, packageName, version string) (
 
 // GetDependencies returns information about dependencies for a specific version of a package
 // for a specific package manager.
-func GetDependencies(packageManager, packageName, version string) (Dependencies, error) {
-	c := client.New(BasePath)
-
-	d, err := getDependencies(c, packageManager, packageName, version)
-	if err != nil {
-		return Dependencies{}, err
-	}
-
-	return d, nil
+func (a *API) GetDependencies(packageManager, packageName, version string) (Dependencies, error) {
+	return getDependencies(a.client, packageManager, packageName, version)
 }
 
 // getDependencies returns a Dependencies object.
@@ -114,15 +85,8 @@ func getDependencies(c *client.Client, packageManager, packageName, version stri
 }
 
 // GetProject returns information about a project (hosted on GitHub, GitLab or BitBucket).
-func GetProject(projectName string) (Project, error) {
-	c := client.New(BasePath)
-
-	p, err := getProject(c, projectName)
-	if err != nil {
-		return Project{}, err
-	}
-
-	return p, nil
+func (a *API) GetProject(projectName string) (Project, error) {
+	return getProject(a.client, projectName)
 }
 
 // getProject returns a Project object.
@@ -138,15 +102,8 @@ func getProject(c *client.Client, projectName string) (Project, error) {
 }
 
 // GetAdvisory returns information about an advisory.
-func GetAdvisory(advisory string) (Advisory, error) {
-	c := client.New(BasePath)
-
-	a, err := getAdvisory(c, advisory)
-	if err != nil {
-		return Advisory{}, err
-	}
-
-	return a, nil
+func (a *API) GetAdvisory(advisory string) (Advisory, error) {
+	return getAdvisory(a.client, advisory)
 }
 
 // getAdvisory returns an Advisory object.
@@ -162,15 +119,8 @@ func getAdvisory(c *client.Client, advisory string) (Advisory, error) {
 }
 
 // GetQuery returns the result of the inputted query.
-func GetQuery(query string) (Package, error) {
-	c := client.New(BasePath)
-
-	q, err := getQuery(c, query)
-	if err != nil {
-		return Package{}, err
-	}
-
-	return q, nil
+func (a *API) GetQuery(query string) (Package, error) {
+	return getQuery(a.client, query)
 }
 
 // getQuery returns a Package object given a query.

--- a/pkg/depsdev/api.go
+++ b/pkg/depsdev/api.go
@@ -21,6 +21,24 @@ import (
 	"github.com/edoardottt/depsdev/pkg/client"
 )
 
+type API struct {
+	client *client.Client
+}
+
+func NewAPI() *API {
+	return &API{
+		client: client.New(BasePath),
+	}
+}
+
+func (a *API) GetInfo(packageManager, packageName string) (Package, error) {
+	return getPackage(a.client, packageManager, packageName)
+}
+
+func (a *API) GetVersion(packageManager, packageName, version string) (Version, error) {
+	return getVersion(a.client, packageManager, packageName, version)
+}
+
 // GetInfo returns information about a package for a specific package manager.
 func GetInfo(packageManager, packageName string) (Package, error) {
 	c := client.New(BasePath)

--- a/pkg/depsdev/api_internal_test.go
+++ b/pkg/depsdev/api_internal_test.go
@@ -14,7 +14,6 @@ var (
 )
 
 func BenchmarkGetInfo(b *testing.B) {
-
 	b.Run("function", func(b *testing.B) {
 		var (
 			info Package

--- a/pkg/depsdev/api_test.go
+++ b/pkg/depsdev/api_test.go
@@ -1,0 +1,66 @@
+package depsdev
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	p   Package
+	v   Version
+	api = NewAPI()
+)
+
+func BenchmarkGetInfo(b *testing.B) {
+
+	b.Run("function", func(b *testing.B) {
+		var (
+			info Package
+			err  error
+		)
+		for i := 0; i < b.N; i++ {
+			info, err = GetInfo("npm", "react")
+			require.NoError(b, err)
+		}
+		p = info
+	})
+
+	b.Run("method", func(b *testing.B) {
+		var (
+			info Package
+			err  error
+		)
+		for i := 0; i < b.N; i++ {
+			info, err = api.GetInfo("npm", "react")
+			require.NoError(b, err)
+		}
+		p = info
+	})
+}
+
+func BenchmarkGetVersion(b *testing.B) {
+	b.Run("function", func(b *testing.B) {
+		var (
+			version Version
+			err     error
+		)
+		for i := 0; i < b.N; i++ {
+			version, err = GetVersion("npm", "react", "18.3.0-next-fecc288b7-20221025")
+			require.NoError(b, err)
+		}
+		v = version
+	})
+
+	b.Run("method", func(b *testing.B) {
+		var (
+			version Version
+			err     error
+		)
+		for i := 0; i < b.N; i++ {
+			version, err = api.GetVersion("npm", "react", "18.3.0-next-fecc288b7-20221025")
+			require.NoError(b, err)
+		}
+		v = version
+	})
+}

--- a/pkg/depsdev/api_test.go
+++ b/pkg/depsdev/api_test.go
@@ -3,6 +3,7 @@ package depsdev
 import (
 	"testing"
 
+	"github.com/edoardottt/depsdev/pkg/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +21,8 @@ func BenchmarkGetInfo(b *testing.B) {
 			err  error
 		)
 		for i := 0; i < b.N; i++ {
-			info, err = GetInfo("npm", "react")
+			client := client.New(BasePath)
+			info, err = getPackage(client, "npm", "react")
 			require.NoError(b, err)
 		}
 		p = info
@@ -46,7 +48,8 @@ func BenchmarkGetVersion(b *testing.B) {
 			err     error
 		)
 		for i := 0; i < b.N; i++ {
-			version, err = GetVersion("npm", "react", "18.3.0-next-fecc288b7-20221025")
+			client := client.New(BasePath)
+			version, err = getVersion(client, "npm", "react", "18.3.0-next-fecc288b7-20221025")
 			require.NoError(b, err)
 		}
 		v = version


### PR DESCRIPTION
fixes #29 