### PR TITLE
feat: add support for GetProjectBatch and GetVersionBatch

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -15,6 +15,7 @@ Free access to dependencies, licenses, advisories, and other critical health and
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net"
@@ -113,4 +114,13 @@ func (c *Client) RawGet(path string) ([]byte, error) {
 
 func (c *Client) Get(path string, target interface{}) error {
 	return c.do(http.MethodGet, path, target, nil)
+}
+
+func (c *Client) Post(path string, body interface{}, target interface{}) error {
+	buf := bytes.Buffer{}
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		return err
+	}
+
+	return c.do(http.MethodPost, path, target, &buf)
 }

--- a/pkg/depsdev/definitions/version.go
+++ b/pkg/depsdev/definitions/version.go
@@ -49,3 +49,9 @@ type RelatedProjects struct {
 	RelationProvenance string     `json:"relationProvenance,omitempty"`
 	RelationType       string     `json:"relationType,omitempty"`
 }
+
+type VersionBatchRequest struct {
+	PackageManager string `json:"system"`
+	PackageName    string `json:"name"`
+	Version        string `json:"version"`
+}

--- a/pkg/depsdev/v3alpha/api_test.go
+++ b/pkg/depsdev/v3alpha/api_test.go
@@ -18,9 +18,11 @@ import (
 	"encoding/json"
 	"log"
 	"testing"
+	"time"
 
 	def "github.com/edoardottt/depsdev/pkg/depsdev/definitions"
 	depsdev "github.com/edoardottt/depsdev/pkg/depsdev/v3alpha"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -521,4 +523,148 @@ func TestGetRequirements(t *testing.T) {
 
 		require.Equal(t, r, got)
 	})
+}
+
+func TestGetVersionBatch(t *testing.T) {
+	t.Run("GetVersion batch", func(t *testing.T) {
+		iter, err := api.GetVersionBatch([]def.VersionBatchRequest{
+			{
+				PackageManager: "NPM",
+				PackageName:    "@colors/colors",
+				Version:        "1.5.0",
+			},
+			{
+				PackageManager: "NPM",
+				PackageName:    "defangjs",
+				Version:        "1.0.7",
+			},
+		})
+		require.Nil(t, err)
+		assert.NotNil(t, iter)
+		defer iter.Close()
+
+		expected := []def.Version{
+			{
+				VersionKey: def.VersionKey{
+					System:  "NPM",
+					Name:    "@colors/colors",
+					Version: "1.5.0",
+				},
+				IsDefault:    false,
+				Licenses:     []string{"MIT"},
+				AdvisoryKeys: []def.AdvisoryKeys{},
+				Links: []def.Links{
+					{
+						Label: "HOMEPAGE",
+						URL:   "https://github.com/DABH/colors.js"},
+					{
+						Label: "ISSUE_TRACKER",
+						URL:   "https://github.com/DABH/colors.js/issues",
+					},
+					{
+						Label: "ORIGIN",
+						URL:   "https://registry.npmjs.org/@colors%2Fcolors/1.5.0",
+					},
+					{
+						Label: "SOURCE_REPO",
+						URL:   "git+ssh://git@github.com/DABH/colors.js.git",
+					},
+				},
+				SlsaProvenances: []def.SLSAProvenances{},
+				PublishedAt:     time.Date(2022, time.February, 12, 7, 39, 4, 0, time.UTC),
+				Registries:      []string{"https://registry.npmjs.org/"},
+				RelatedProjects: []def.RelatedProjects{
+					{
+						ProjectKey:         def.ProjectKey{ID: "github.com/dabh/colors.js"},
+						RelationProvenance: "UNVERIFIED_METADATA",
+						RelationType:       "ISSUE_TRACKER",
+					},
+					{
+						ProjectKey:         def.ProjectKey{ID: "github.com/dabh/colors.js"},
+						RelationProvenance: "UNVERIFIED_METADATA",
+						RelationType:       "SOURCE_REPO"},
+				},
+			},
+			{
+				VersionKey: def.VersionKey{
+					System:  "NPM",
+					Name:    "defangjs",
+					Version: "1.0.7",
+				},
+				IsDefault:    true,
+				Licenses:     []string{"GPL-3.0"},
+				AdvisoryKeys: []def.AdvisoryKeys{},
+				Links: []def.Links{
+					{
+						Label: "HOMEPAGE",
+						URL:   "https://github.com/edoardottt/defangjs#readme",
+					},
+					{
+
+						Label: "ISSUE_TRACKER",
+						URL:   "https://github.com/edoardottt/defangjs/issues",
+					},
+					{
+
+						Label: "ORIGIN",
+						URL:   "https://registry.npmjs.org/defangjs/1.0.7",
+					},
+					{
+
+						Label: "SOURCE_REPO",
+						URL:   "git+https://github.com/edoardottt/defangjs.git",
+					},
+				},
+				SlsaProvenances: []def.SLSAProvenances{},
+				PublishedAt:     time.Date(2023, time.May, 16, 9, 48, 31, 0, time.UTC),
+				Registries:      []string{"https://registry.npmjs.org/"},
+				RelatedProjects: []def.RelatedProjects{
+					{
+						ProjectKey:         def.ProjectKey{ID: "github.com/edoardottt/defangjs"},
+						RelationProvenance: "UNVERIFIED_METADATA",
+						RelationType:       "ISSUE_TRACKER",
+					},
+					{
+						ProjectKey:         def.ProjectKey{ID: "github.com/edoardottt/defangjs"},
+						RelationProvenance: "UNVERIFIED_METADATA",
+						RelationType:       "SOURCE_REPO",
+					},
+				},
+			},
+		}
+		results, err := consumeIter(iter)
+		require.NoError(t, err)
+
+		assert.Equal(t, expected, results)
+	})
+}
+
+func TestGetProjectBatch(t *testing.T) {
+	t.Run("GetProject batch", func(t *testing.T) {
+		iter, err := api.GetProjectBatch([]string{
+			"github.com/edoardottt/depsdev",
+			"github.com/facebook/react",
+			"github.com/angular/angular",
+		})
+		require.Nil(t, err)
+		assert.NotNil(t, iter)
+		defer iter.Close()
+
+		results, err := consumeIter(iter)
+		require.NoError(t, err)
+
+		assert.Equal(t, 3, len(results))
+	})
+}
+
+func consumeIter[T any](iter *depsdev.Iterator[T]) ([]T, error) {
+	l := []T{}
+	for iter.Next() {
+		v, err := iter.Item()
+		if err != nil {
+			return nil, err
+		}
+		l = append(l, v)
+	}
+	return l, nil
 }

--- a/pkg/depsdev/v3alpha/iterator.go
+++ b/pkg/depsdev/v3alpha/iterator.go
@@ -1,0 +1,37 @@
+package depsdev
+
+type batchJob[T any] struct {
+	Item T
+	Err  error
+}
+
+type Iterator[T any] struct {
+	cIn     <-chan batchJob[T]
+	item    T
+	err     error
+	hasNext bool
+
+	cancel func()
+}
+
+func (v *Iterator[T]) Next() bool {
+	bj, ok := <-v.cIn
+	if !ok {
+		return false
+	}
+
+	v.err = bj.Err
+	v.item = any(bj.Item).(T)
+
+	return true
+}
+
+func (v *Iterator[T]) Item() (T, error) {
+	return v.item, v.err
+}
+
+func (v *Iterator[T]) Close() {
+	if v.cancel != nil {
+		v.cancel()
+	}
+}


### PR DESCRIPTION
The API for both endpoint is paginated, so this implementation return an iterator that allow the library user to controle how he wants to consume the response.